### PR TITLE
Removed Space after closing PHP Tag

### DIFF
--- a/src/Jade/Filter/Php.php
+++ b/src/Jade/Filter/Php.php
@@ -30,6 +30,6 @@ class Php implements FilterInterface
             $data .= ' ?> ' . $compiler->subCompiler()->compile($n) . '<?php ';
         }
 
-        return $data ? '<?php ' . $data . ' ?> ' : $data;
+        return $data ? '<?php ' . $data . ' ?>' : $data;
     }
 }


### PR DESCRIPTION
IMHO it's better if the PHP Filter does not produce any space in the output. Take for example the following snippet:

```
span Text1
:php
  $var1 = "Test";
span Text2
```

It's better if the result is

`<span>Text 1</span><?php $var1 = "Test"; ?><span>Text 2</span>`

Otherwise, there's always an unwanted space between the spans in the browser output and it's not possible to join directly two inline elements.
