### PR TITLE
I've made some changes

### DIFF
--- a/src/Jade/Jade.php
+++ b/src/Jade/Jade.php
@@ -113,6 +113,11 @@ class Jade extends Options
         else $this->options['basedir'] = $path;
     }
 
+    // assign
+    public function assign($variables, $value = null) {
+        $this->share($variables,$value);
+    }
+
 
     /**
      * Compile PHP code from a Pug input or a Pug file.
@@ -127,7 +132,6 @@ class Jade extends Options
     public function compile($input, $filename = null)
     {
         $parser = new Parser($this->options['basedir'] . $input, $filename, $this->options);
-        //$parser = new Parser($input, $filename, $this->options);
         $compiler = new Compiler($this->options, $this->filters, $parser->getFilename());
         $php = $compiler->compile($parser->parse());
         if (version_compare(PHP_VERSION, '7.0.0') < 0) {
@@ -162,11 +166,10 @@ class Jade extends Options
      */
     public function render($input, $filename = null, array $vars = array())
     {
-         // tom - auto add extension
+         // auto add extension
         if($this->options['extension'] && substr($input,-(strlen($this->options['extension']))) != $this->options['extension']) {
             $input .= $this->options['extension'];
         }
-        // ended tom added
 
         if (is_array($filename) || is_object($filename)) {
             $vars = $filename;

--- a/src/Jade/Jade.php
+++ b/src/Jade/Jade.php
@@ -101,6 +101,19 @@ class Jade extends Options
         return $requirements;
     }
 
+
+    /*  setDir , output */
+    public function output($filename,$return = false) {
+        if($return) return $this->render($filename);
+        else echo $this->render($filename);
+    }
+
+    public function setDir($path) {
+        if(!$path) unset($this->options['basedir']);
+        else $this->options['basedir'] = $path;
+    }
+
+
     /**
      * Compile PHP code from a Pug input or a Pug file.
      *
@@ -113,7 +126,8 @@ class Jade extends Options
      */
     public function compile($input, $filename = null)
     {
-        $parser = new Parser($input, $filename, $this->options);
+        $parser = new Parser($this->options['basedir'] . $input, $filename, $this->options);
+        //$parser = new Parser($input, $filename, $this->options);
         $compiler = new Compiler($this->options, $this->filters, $parser->getFilename());
         $php = $compiler->compile($parser->parse());
         if (version_compare(PHP_VERSION, '7.0.0') < 0) {
@@ -148,6 +162,12 @@ class Jade extends Options
      */
     public function render($input, $filename = null, array $vars = array())
     {
+         // tom - auto add extension
+        if($this->options['extension'] && substr($input,-(strlen($this->options['extension']))) != $this->options['extension']) {
+            $input .= $this->options['extension'];
+        }
+        // ended tom added
+
         if (is_array($filename) || is_object($filename)) {
             $vars = $filename;
             $filename = null;


### PR DESCRIPTION
- `setDir` to change `basedir` any time
- Auto add template extension, can use `render('index');` instead of `render('index.pug');` 
- Use `assign` instead of `share` for assigning variables.
- Added `output` method to display template directly or return rendered template.