### PR TITLE
Fix space after tag interpolation

### DIFF
--- a/src/Jade/Compiler/TagVisitor.php
+++ b/src/Jade/Compiler/TagVisitor.php
@@ -64,6 +64,7 @@ abstract class TagVisitor extends Visitor
             if (
                 $nodes[$i] instanceof Text &&
                 $nodes[$i - 1] instanceof Block &&
+                $nodes[$i - 1]->nodes[0] instanceof Tag &&
                 !preg_match('/^\s/', $nodes[$i]->value)
             ) {
                 $nodes[$i]->value = ' ' . $nodes[$i]->value;

--- a/src/Jade/Compiler/TagVisitor.php
+++ b/src/Jade/Compiler/TagVisitor.php
@@ -2,6 +2,7 @@
 
 namespace Jade\Compiler;
 
+use Jade\Nodes\Block;
 use Jade\Nodes\Tag;
 use Jade\Nodes\Text;
 
@@ -58,6 +59,14 @@ abstract class TagVisitor extends Visitor
                 !preg_match('/\s$/', $nodes[$i - 1]->value)
             ) {
                 $nodes[$i - 1]->value .= ' ';
+            }
+
+            if (
+                $nodes[$i] instanceof Text &&
+                $nodes[$i - 1] instanceof Block &&
+                !preg_match('/^\s/', $nodes[$i]->value)
+            ) {
+                $nodes[$i]->value = ' ' . $nodes[$i]->value;
             }
         }
     }

--- a/src/Jade/Compiler/TagVisitor.php
+++ b/src/Jade/Compiler/TagVisitor.php
@@ -65,7 +65,8 @@ abstract class TagVisitor extends Visitor
                 $nodes[$i] instanceof Text &&
                 $nodes[$i - 1] instanceof Block &&
                 $nodes[$i - 1]->nodes[0] instanceof Tag &&
-                !preg_match('/^\s/', $nodes[$i]->value)
+                !preg_match('/^\s/', $nodes[$i]->value) &&
+                !empty($nodes[$i]->value)
             ) {
                 $nodes[$i]->value = ' ' . $nodes[$i]->value;
             }

--- a/tests/features/templates.php
+++ b/tests/features/templates.php
@@ -92,5 +92,9 @@ class JadeTemplatesTest extends PHPUnit_Framework_TestCase
         $html = $pug->render("p this is #[a(href='#') test] string");
 
         $this->assertSame('<p>this is <a href="#">test</a> string</p>', $html);
+
+        $html = $pug->render("p this is #[a(href='#') test string]");
+
+        $this->assertSame('<p>this is <a href="#">test string</a></p>', $html);
     }
 }

--- a/tests/features/templates.php
+++ b/tests/features/templates.php
@@ -88,5 +88,9 @@ class JadeTemplatesTest extends PHPUnit_Framework_TestCase
         $html = $pug->render("p\n  | #[i a] #[i b]");
 
         $this->assertSame('<p><i>a</i> <i>b</i></p>', $html);
+
+        $html = $pug->render("p this is #[a(href='#') test] string");
+
+        $this->assertSame('<p>this is <a href="#">test</a> string</p>', $html);
     }
 }


### PR DESCRIPTION
This fix errors in tag interpolation.
Current behavior:
```pug
p This is #[a(href="http://someurl.com") example] string.
```
Result:
```html
<p>This is <a href="http://someurl.com">example</a>string.</p>
```
Space after anchor is lost.
Need:
```html
<p>This is <a href="http://someurl.com">example</a> string.</p>
```
I wanted to write a test for this case, but do not pass the tests. it was not possible to make a fix quickly.