### PR TITLE
Fix error when using Laravel's Eloquent methods calls

### DIFF
--- a/src/Jade/Compiler/CompilerFacade.php
+++ b/src/Jade/Compiler/CompilerFacade.php
@@ -83,7 +83,7 @@ abstract class CompilerFacade extends ValuesCompiler
         if (method_exists($anything, $method = 'get' . ucfirst($key))) {
             return $anything->$method();
         } elseif (method_exists($anything, $key)) {
-            return [$anything, $key];
+            return array($anything, $key);
         } elseif (isset($anything->$key)) {
             return $anything->$key;
         }

--- a/src/Jade/Compiler/CompilerFacade.php
+++ b/src/Jade/Compiler/CompilerFacade.php
@@ -87,8 +87,6 @@ abstract class CompilerFacade extends ValuesCompiler
         } elseif (isset($anything->$key)) {
             return $anything->$key;
         }
-
-        return null;
     }
 
     /**

--- a/src/Jade/Compiler/CompilerFacade.php
+++ b/src/Jade/Compiler/CompilerFacade.php
@@ -80,15 +80,15 @@ abstract class CompilerFacade extends ValuesCompiler
      */
     public static function getPropertyFromObject($anything, $key)
     {
-        return isset($anything->$key)
-            ? $anything->$key
-            : (method_exists($anything, $method = 'get' . ucfirst($key))
-                ? $anything->$method()
-                : (method_exists($anything, $key)
-                    ? array($anything, $key)
-                    : null
-                )
-            );
+        if (method_exists($anything, $method = 'get' . ucfirst($key))) {
+            return $anything->$method();
+        } elseif (method_exists($anything, $key)) {
+            return [$anything, $key];
+        } elseif (isset($anything->$key)) {
+            return $anything->$key;
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Hello! I'm using `pug-php` via `pug-laravel` package and encountered error, when use Laravel's Eloquent methods in Pug:
```
ErrorException in HasAttributes.php line 403:
Relationship method must return an object of type Illuminate\Database\Eloquent\Relations\Relation (View: /var/contributing/php-pug-eloquent-bug-demo/resources/views/welcome.pug)
```

You could check out demo code here:
https://github.com/vitalybaev/php-pug-eloquent-bug-demo
and live result:

Normal class method:
http://php-pug-bug.vitalybaev.ru/test_normal_class

Eloquent class method:
http://php-pug-bug.vitalybaev.ru/test_eloquent.

I've changed the order of cheks in `src/Jade/Compiler/CompilerFacade::getPropertyFromObject` 

All test passed.
