### PR TITLE
Refactoring tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.8 <6.0",
+        "phpunit/phpunit": ">=4.8.35 <6.0",
         "codeclimate/php-test-reporter": ">=0.3"
     },
     "autoload": {

--- a/tests/example/example.php
+++ b/tests/example/example.php
@@ -1,11 +1,12 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
 /**
  * Test server example
  */
-class PugExampleTest extends PHPUnit_Framework_TestCase
+class PugExampleTest extends TestCase
 {
     protected function simpleHtml($contents)
     {

--- a/tests/features/cache.php
+++ b/tests/features/cache.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
 class PugTest extends Pug
@@ -26,7 +27,7 @@ class PugTest extends Pug
     }
 }
 
-class PugCacheTest extends PHPUnit_Framework_TestCase
+class PugCacheTest extends TestCase
 {
     protected function emptyDirectory($dir)
     {

--- a/tests/features/exceptions.php
+++ b/tests/features/exceptions.php
@@ -1,12 +1,13 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Parser;
 use Pug\Pug;
 
 class EmulateBugException extends \Exception {}
 class OnlyOnceException extends \Exception {}
 
-class PugExceptionsTest extends PHPUnit_Framework_TestCase
+class PugExceptionsTest extends TestCase
 {
     static public function emulateBug()
     {

--- a/tests/features/expressionLanguage.php
+++ b/tests/features/expressionLanguage.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
-class PugExpressionLanguageTest extends PHPUnit_Framework_TestCase
+class PugExpressionLanguageTest extends TestCase
 {
     public function testJsExpression()
     {

--- a/tests/features/facade.php
+++ b/tests/features/facade.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Facade as Pug;
 
-class FacadeTest extends PHPUnit_Framework_TestCase
+class FacadeTest extends TestCase
 {
     public function testFacade()
     {

--- a/tests/features/filter.php
+++ b/tests/features/filter.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
 class ParseMethodFilter
@@ -15,7 +16,7 @@ class SpecialScript extends \Pug\Filter\AbstractFilter
     protected $tag = 'script';
 }
 
-class PugFilterTest extends PHPUnit_Framework_TestCase
+class PugFilterTest extends TestCase
 {
     /**
      * @group filters

--- a/tests/features/hooks.php
+++ b/tests/features/hooks.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
-class PugHooksTest extends PHPUnit_Framework_TestCase
+class PugHooksTest extends TestCase
 {
     public function testPreRender()
     {

--- a/tests/features/issues.php
+++ b/tests/features/issues.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
-class PugIssuesTest extends PHPUnit_Framework_TestCase
+class PugIssuesTest extends TestCase
 {
     public function testIssue62()
     {

--- a/tests/features/keyword.php
+++ b/tests/features/keyword.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Phug\AbstractExtension;
 use Phug\Compiler\Event\NodeEvent;
 use Phug\Parser\Node\ElementNode;
@@ -46,7 +47,7 @@ class BadOptionType
 {
 }
 
-class PugKeywordTest extends PHPUnit_Framework_TestCase
+class PugKeywordTest extends TestCase
 {
     /**
      * @group keywords

--- a/tests/features/obsolete.php
+++ b/tests/features/obsolete.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 class JadeFilter extends \Jade\Filter\AbstractFilter
 {
     // Obsolete
@@ -15,7 +17,7 @@ class NodeStringFilter extends \Pug\Filter\AbstractFilter
 
 include_once __DIR__ . '/../lib/LegacyFilterNode.php';
 
-class PugObsoleteTest extends PHPUnit_Framework_TestCase
+class PugObsoleteTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/features/pugjs.php
+++ b/tests/features/pugjs.php
@@ -1,9 +1,10 @@
 <?php
 
 use NodejsPhpFallback\NodejsPhpFallback;
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
-class PugJsTest extends PHPUnit_Framework_TestCase
+class PugJsTest extends TestCase
 {
     /**
      * @group pugjs

--- a/tests/features/pugjs.php
+++ b/tests/features/pugjs.php
@@ -37,7 +37,7 @@ class PugJsTest extends TestCase
         $html = trim($pug->renderFile($source));
         clearstatcache();
 
-        self::assertTrue(file_exists($cache));
+        self::assertFileExists($cache);
 
         self::assertSame('<html><body><h1>Title</h1></body></html>', $html);
 

--- a/tests/features/requirements.php
+++ b/tests/features/requirements.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
-class PugRequirementsTest extends PHPUnit_Framework_TestCase
+class PugRequirementsTest extends TestCase
 {
     public function testCacheFolderExists()
     {

--- a/tests/features/settings.php
+++ b/tests/features/settings.php
@@ -1,11 +1,12 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Phug\Phug;
 use Pug\Pug;
 
 include_once __DIR__.'/../lib/escape.php';
 
-class PugSettingsTest extends PHPUnit_Framework_TestCase
+class PugSettingsTest extends TestCase
 {
     static private function rawHtml($html, $convertSingleQuote = true)
     {

--- a/tests/features/share.php
+++ b/tests/features/share.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
-class ShareTest extends PHPUnit_Framework_TestCase
+class ShareTest extends TestCase
 {
     public function testShare()
     {

--- a/tests/features/templates.php
+++ b/tests/features/templates.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
-class PugTemplatesTest extends PHPUnit_Framework_TestCase
+class PugTemplatesTest extends TestCase
 {
     public function caseProvider()
     {

--- a/tests/features/whiteSpace.php
+++ b/tests/features/whiteSpace.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
-class PugWhiteSpaceTest extends PHPUnit_Framework_TestCase
+class PugWhiteSpaceTest extends TestCase
 {
     public function testTextarea()
     {

--- a/tests/performance/cache.php
+++ b/tests/performance/cache.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
-class PugCachePerformanceTest extends PHPUnit_Framework_TestCase
+class PugCachePerformanceTest extends TestCase
 {
     protected function getPerformanceTemplate($template)
     {


### PR DESCRIPTION
I've refactored some tests, using:

- [`assertFileExists`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertFileExists) instead of `assertTrue(file_exists())`.

I've also used `PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase`. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.